### PR TITLE
Rename package from requestId to traceBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF)](https://php.net/)
 [![Minimum Symfony Version](https://img.shields.io/badge/symfony-%3E%3D%206.3-brightgreen)](https://symfony.com/doc/current/validation.html)
-![Run tests](https://github.com/123inkt/symfony-request-id/actions/workflows/test.yml/badge.svg)
+![Run tests](https://github.com/123inkt/symfony-trace-bundle/actions/workflows/test.yml/badge.svg)
 
-# Symfony Request Id
+# Symfony Trace Bundle
 
 *Based on [chrisguitarguy/RequestIdBundle](https://github.com/chrisguitarguy/RequestIdBundle)*
 
@@ -18,7 +18,7 @@ be available in:
 
 Use [Composer](https://getcomposer.org/).
 ```
-composer require digitalrevolution/symfony-request-id
+composer require digitalrevolution/symfony-trace-bundle
 ```
 
 And one of the UUID generator libraries:
@@ -29,28 +29,29 @@ composer require symfony/uid
 ```
 
 Then enable the bundle in your `/config/bundles.php`:
+
 ```php
 # /config/bundles.php
 <?php
 
 return [
     ...
-    DR\SymfonyRequestId\RequestIdBundle::class => ['all' => true],
+    DR\SymfonyTraceBundle\TraceBundle::class => ['all' => true],
 ];
 ```
 
 ## Configuration
 
 ```php
-# /config/packages/symfony-request-id.php
+# /config/packages/symfony-trace-bundle.php
 <?php
 declare(strict_types=1);
 
-use DR\SymfonyRequestId\Generator\RamseyUuid4Generator;
-use DR\SymfonyRequestId\SimpleIdStorage;
-use Symfony\Config\SymfonyRequestIdConfig;
+use DR\SymfonyTraceBundle\Generator\RamseyUuid4Generator;
+use DR\SymfonyTraceBundle\SimpleIdStorage;
+use Symfony\Config\SymfonyTraceConfig;
 
-return static function (SymfonyRequestIdConfig $config): void {
+return static function (SymfonyTraceConfig $config): void {
     // The header which the bundle inspects for the incoming trace ID
     // if this is not set an ID will be generated and set at this header
     $config->requestHeader('X-Trace-Id');
@@ -65,11 +66,11 @@ return static function (SymfonyRequestIdConfig $config): void {
     $config->responseHeader('X-Trace-Id');
 
     // The service key of an object that implements
-    // DR\SymfonyRequestId\IdStorageInterface
+    // DR\SymfonyTraceBundle\IdStorageInterface
     $config->storageService(SimpleIdStorage::class);
 
     // The service key of an object that implements
-    // DR\SymfonyRequestId\IdGeneratorInterface
+    // DR\SymfonyTraceBundle\Generator\IdGeneratorInterface
     // Optional, will default to Symfony's Uuid or Ramsey's Uuid.
     $config->generatorService(RamseyUuid4Generator::class);
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then enable the bundle in your `/config/bundles.php`:
 
 return [
     ...
-    DR\SymfonyTraceBundle\TraceBundle::class => ['all' => true],
+    DR\SymfonyTraceBundle\SymfonyTraceBundle::class => ['all' => true],
 ];
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "digitalrevolution/symfony-request-id",
-    "description": "Add request ID's to your Symfony application. ",
+    "name": "digitalrevolution/symfony-trace-bundle",
+    "description": "Add tracing to your Symfony application. ",
     "type": "symfony-bundle",
     "license": "MIT",
     "minimum-stability": "stable",
@@ -10,7 +10,8 @@
             "symfony/flex": true,
             "symfony/runtime": true,
             "phpstan/extension-installer": true
-        }
+        },
+        "lock": false
     },
     "require": {
         "php": ">=8.1",
@@ -48,13 +49,13 @@
     },
     "autoload": {
         "psr-4": {
-            "DR\\SymfonyRequestId\\": "src/"
+            "DR\\SymfonyTraceBundle\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "DR\\SymfonyRequestId\\Tests\\Unit\\": "tests/Unit/",
-            "DR\\SymfonyRequestId\\Tests\\": "tests/"
+            "DR\\SymfonyTraceBundle\\Tests\\Unit\\": "tests/Unit/",
+            "DR\\SymfonyTraceBundle\\Tests\\": "tests/"
         }
     },
     "scripts": {

--- a/phpmd.baseline.xml
+++ b/phpmd.baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <phpmd-baseline>
-  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="src/DependencyInjection/SymfonyRequestIdExtension.php" method="loadInternal"/>
-  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="src/DependencyInjection/SymfonyRequestIdExtension.php" method="loadInternal"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="src/DependencyInjection/SymfonyTraceExtension.php" method="loadInternal"/>
+  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="src/DependencyInjection/SymfonyTraceExtension.php" method="loadInternal"/>
 </phpmd-baseline>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,36 +6,36 @@ parameters:
 			path: src/DependencyInjection/Configuration.php
 
 		-
-			message: "#^Parameter \\#1 \\$mergedConfig \\(array\\{request_header\\: string, trust_request_header\\: bool, response_header\\: string, storage_service\\: string\\|null, generator_service\\: string\\|null, enable_monolog\\: bool, enable_console\\: bool, enable_messenger\\: bool, \\.\\.\\.\\}\\) of method DR\\\\SymfonyRequestId\\\\DependencyInjection\\\\SymfonyRequestIdExtension\\:\\:loadInternal\\(\\) should be contravariant with parameter \\$mergedConfig \\(array\\) of method Symfony\\\\Component\\\\HttpKernel\\\\DependencyInjection\\\\ConfigurableExtension\\:\\:loadInternal\\(\\)$#"
+			message: "#^Parameter \\#1 \\$mergedConfig \\(array\\{request_header\\: string, trust_request_header\\: bool, response_header\\: string, storage_service\\: string\\|null, generator_service\\: string\\|null, enable_monolog\\: bool, enable_console\\: bool, enable_messenger\\: bool, \\.\\.\\.\\}\\) of method DR\\\\SymfonyTraceBundle\\\\DependencyInjection\\\\SymfonyTraceExtension\\:\\:loadInternal\\(\\) should be contravariant with parameter \\$mergedConfig \\(array\\) of method Symfony\\\\Component\\\\HttpKernel\\\\DependencyInjection\\\\ConfigurableExtension\\:\\:loadInternal\\(\\)$#"
 			count: 1
-			path: src/DependencyInjection/SymfonyRequestIdExtension.php
+			path: src/DependencyInjection/SymfonyTraceExtension.php
 
 		-
-			message: "#^Method DR\\\\SymfonyRequestId\\\\Http\\\\TraceIdAwareHttpClient\\:\\:request\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Http/TraceIdAwareHttpClient.php
-
-		-
-			message: "#^Method DR\\\\SymfonyRequestId\\\\Http\\\\TraceIdAwareHttpClient\\:\\:withOptions\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: "#^Method DR\\\\SymfonyTraceBundle\\\\Http\\\\TraceIdAwareHttpClient\\:\\:request\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Http/TraceIdAwareHttpClient.php
 
 		-
-			message: "#^Method DR\\\\SymfonyRequestId\\\\Monolog\\\\TraceIdProcessor\\:\\:__invoke\\(\\) has parameter \\$record with no value type specified in iterable type array\\.$#"
+			message: "#^Method DR\\\\SymfonyTraceBundle\\\\Http\\\\TraceIdAwareHttpClient\\:\\:withOptions\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Http/TraceIdAwareHttpClient.php
+
+		-
+			message: "#^Method DR\\\\SymfonyTraceBundle\\\\Monolog\\\\TraceIdProcessor\\:\\:__invoke\\(\\) has parameter \\$record with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Monolog/TraceIdProcessor.php
 
 		-
-			message: "#^Method DR\\\\SymfonyRequestId\\\\Monolog\\\\TraceIdProcessor\\:\\:__invoke\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: "#^Method DR\\\\SymfonyTraceBundle\\\\Monolog\\\\TraceIdProcessor\\:\\:__invoke\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Monolog/TraceIdProcessor.php
 
 		-
-			message: "#^Return type \\(array\\|Monolog\\\\LogRecord\\) of method DR\\\\SymfonyRequestId\\\\Monolog\\\\TraceIdProcessor\\:\\:__invoke\\(\\) should be covariant with return type \\(Monolog\\\\LogRecord\\) of method Monolog\\\\Processor\\\\ProcessorInterface\\:\\:__invoke\\(\\)$#"
+			message: "#^Return type \\(array\\|Monolog\\\\LogRecord\\) of method DR\\\\SymfonyTraceBundle\\\\Monolog\\\\TraceIdProcessor\\:\\:__invoke\\(\\) should be covariant with return type \\(Monolog\\\\LogRecord\\) of method Monolog\\\\Processor\\\\ProcessorInterface\\:\\:__invoke\\(\\)$#"
 			count: 1
 			path: src/Monolog/TraceIdProcessor.php
 
 		-
-			message: "#^Method DR\\\\SymfonyRequestId\\\\Tests\\\\Functional\\\\App\\\\Monolog\\\\MemoryHandler\\:\\:write\\(\\) has parameter \\$record with no value type specified in iterable type array\\.$#"
+			message: "#^Method DR\\\\SymfonyTraceBundle\\\\Tests\\\\Functional\\\\App\\\\Monolog\\\\MemoryHandler\\:\\:write\\(\\) has parameter \\$record with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Functional/App/Monolog/MemoryHandler.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          cacheDirectory=".phpunit.cache"
          requireCoverageMetadata="true">
     <php>
-        <env name="KERNEL_CLASS" value="DR\SymfonyRequestId\Tests\Functional\App\TestKernel"/>
+        <env name="KERNEL_CLASS" value="DR\SymfonyTraceBundle\Tests\Functional\App\TestKernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
     <testsuites>

--- a/src/DependencyInjection/Compiler/HttpClientTraceIdPass.php
+++ b/src/DependencyInjection/Compiler/HttpClientTraceIdPass.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\DependencyInjection\Compiler;
+namespace DR\SymfonyTraceBundle\DependencyInjection\Compiler;
 
-use DR\SymfonyRequestId\DependencyInjection\SymfonyRequestIdExtension;
-use DR\SymfonyRequestId\Http\TraceIdAwareHttpClient;
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\DependencyInjection\SymfonyTraceExtension;
+use DR\SymfonyTraceBundle\Http\TraceIdAwareHttpClient;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Parameter;
@@ -22,13 +22,13 @@ class HttpClientTraceIdPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if ($container->hasParameter(SymfonyRequestIdExtension::PARAMETER_KEY . '.http_client.enabled') === false ||
-            $container->getParameter(SymfonyRequestIdExtension::PARAMETER_KEY . '.http_client.enabled') === false
+        if ($container->hasParameter(SymfonyTraceExtension::PARAMETER_KEY . '.http_client.enabled') === false ||
+            $container->getParameter(SymfonyTraceExtension::PARAMETER_KEY . '.http_client.enabled') === false
         ) {
             return;
         }
 
-        if ($container->getParameter(SymfonyRequestIdExtension::PARAMETER_KEY . '.http_client.tag_default_client') === true &&
+        if ($container->getParameter(SymfonyTraceExtension::PARAMETER_KEY . '.http_client.tag_default_client') === true &&
             $container->hasDefinition('http_client')
         ) {
             $container->getDefinition('http_client')
@@ -42,7 +42,7 @@ class HttpClientTraceIdPass implements CompilerPassInterface
                 ->setArguments([
                     new Reference($id . '.trace_id' . '.inner'),
                     new Reference(IdStorageInterface::class),
-                    new Parameter(SymfonyRequestIdExtension::PARAMETER_KEY . '.http_client.header')
+                    new Parameter(SymfonyTraceExtension::PARAMETER_KEY . '.http_client.header')
                 ])
                 ->setDecoratedService($id, null, 1);
         }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\DependencyInjection;
+namespace DR\SymfonyTraceBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -16,7 +16,7 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $tree = new TreeBuilder('symfony_request_id');
+        $tree = new TreeBuilder('symfony_trace');
         /** @var ArrayNodeDefinition $node */
         $node = $tree->getRootNode();
         $node

--- a/src/DependencyInjection/SymfonyTraceExtension.php
+++ b/src/DependencyInjection/SymfonyTraceExtension.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\DependencyInjection;
+namespace DR\SymfonyTraceBundle\DependencyInjection;
 
-use DR\SymfonyRequestId\EventSubscriber\CommandSubscriber;
-use DR\SymfonyRequestId\EventSubscriber\MessageBusSubscriber;
-use DR\SymfonyRequestId\EventSubscriber\TraceIdSubscriber;
-use DR\SymfonyRequestId\Generator\RamseyUuid4Generator;
-use DR\SymfonyRequestId\Generator\SymfonyUuid4Generator;
-use DR\SymfonyRequestId\Monolog\TraceIdProcessor;
-use DR\SymfonyRequestId\IdGeneratorInterface;
-use DR\SymfonyRequestId\IdStorageInterface;
-use DR\SymfonyRequestId\SimpleIdStorage;
-use DR\SymfonyRequestId\Twig\TraceIdExtension;
+use DR\SymfonyTraceBundle\EventSubscriber\CommandSubscriber;
+use DR\SymfonyTraceBundle\EventSubscriber\MessageBusSubscriber;
+use DR\SymfonyTraceBundle\EventSubscriber\TraceIdSubscriber;
+use DR\SymfonyTraceBundle\Generator\RamseyUuid4Generator;
+use DR\SymfonyTraceBundle\Generator\SymfonyUuid4Generator;
+use DR\SymfonyTraceBundle\Monolog\TraceIdProcessor;
+use DR\SymfonyTraceBundle\IdGeneratorInterface;
+use DR\SymfonyTraceBundle\IdStorageInterface;
+use DR\SymfonyTraceBundle\SimpleIdStorage;
+use DR\SymfonyTraceBundle\Twig\TraceIdExtension;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -26,9 +26,9 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * @codeCoverageIgnore - This is a configuration class, tested by the functional test
  * @internal
  */
-final class SymfonyRequestIdExtension extends ConfigurableExtension
+final class SymfonyTraceExtension extends ConfigurableExtension
 {
-    public const PARAMETER_KEY = 'digital_revolution.symfony_request_id';
+    public const PARAMETER_KEY = 'digital_revolution.symfony_trace';
 
     /**
      * @param array{

--- a/src/DependencyInjection/SymfonyTraceExtension.php
+++ b/src/DependencyInjection/SymfonyTraceExtension.php
@@ -121,8 +121,7 @@ final class SymfonyTraceExtension extends ConfigurableExtension
         }
 
         $container->setParameter(self::PARAMETER_KEY . '.http_client.enabled', false);
-
-        if ($mergedConfig['http_client']['enabled']) {
+        if (isset($mergedConfig['http_client']) && $mergedConfig['http_client']['enabled']) {
             if (interface_exists(HttpClientInterface::class) === false) {
                 throw new LogicException(
                     'HttpClient support cannot be enabled as the HttpClient component is not installed. ' .

--- a/src/EventSubscriber/CommandSubscriber.php
+++ b/src/EventSubscriber/CommandSubscriber.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\EventSubscriber;
+namespace DR\SymfonyTraceBundle\EventSubscriber;
 
-use DR\SymfonyRequestId\IdGeneratorInterface;
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\IdGeneratorInterface;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 

--- a/src/EventSubscriber/MessageBusSubscriber.php
+++ b/src/EventSubscriber/MessageBusSubscriber.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\EventSubscriber;
+namespace DR\SymfonyTraceBundle\EventSubscriber;
 
-use DR\SymfonyRequestId\IdGeneratorInterface;
-use DR\SymfonyRequestId\Messenger\TraceIdStamp;
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\IdGeneratorInterface;
+use DR\SymfonyTraceBundle\Messenger\TraceIdStamp;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;

--- a/src/EventSubscriber/TraceIdSubscriber.php
+++ b/src/EventSubscriber/TraceIdSubscriber.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\EventSubscriber;
+namespace DR\SymfonyTraceBundle\EventSubscriber;
 
-use DR\SymfonyRequestId\IdGeneratorInterface;
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\IdGeneratorInterface;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;

--- a/src/Generator/RamseyUuid4Generator.php
+++ b/src/Generator/RamseyUuid4Generator.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Generator;
+namespace DR\SymfonyTraceBundle\Generator;
 
-use DR\SymfonyRequestId\IdGeneratorInterface;
+use DR\SymfonyTraceBundle\IdGeneratorInterface;
 use Ramsey\Uuid\UuidFactory;
 use Ramsey\Uuid\UuidFactoryInterface;
 

--- a/src/Generator/SymfonyUuid4Generator.php
+++ b/src/Generator/SymfonyUuid4Generator.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Generator;
+namespace DR\SymfonyTraceBundle\Generator;
 
-use DR\SymfonyRequestId\IdGeneratorInterface;
+use DR\SymfonyTraceBundle\IdGeneratorInterface;
 use Symfony\Component\Uid\Factory\UuidFactory;
 use Symfony\Component\Uid\UuidV4;
 

--- a/src/Http/TraceIdAwareHttpClient.php
+++ b/src/Http/TraceIdAwareHttpClient.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Http;
+namespace DR\SymfonyTraceBundle\Http;
 
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;

--- a/src/IdGeneratorInterface.php
+++ b/src/IdGeneratorInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId;
+namespace DR\SymfonyTraceBundle;
 
 /**
  * Generates new (hopefully) unique ID's for incoming requests, as transactionId and if lacking as traceId.
@@ -10,7 +10,7 @@ namespace DR\SymfonyRequestId;
 interface IdGeneratorInterface
 {
     /**
-     * Create a new request ID.
+     * Create a new ID.
      */
     public function generate(): string;
 }

--- a/src/IdStorageInterface.php
+++ b/src/IdStorageInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId;
+namespace DR\SymfonyTraceBundle;
 
 /**
  * Stores the identifiers for the transaction.

--- a/src/Messenger/TraceIdStamp.php
+++ b/src/Messenger/TraceIdStamp.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Messenger;
+namespace DR\SymfonyTraceBundle\Messenger;
 
 use Symfony\Component\Messenger\Stamp\StampInterface;
 

--- a/src/Monolog/TraceIdProcessor.php
+++ b/src/Monolog/TraceIdProcessor.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Monolog;
+namespace DR\SymfonyTraceBundle\Monolog;
 
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use Monolog\LogRecord;
 use Monolog\Processor\ProcessorInterface;
 

--- a/src/SimpleIdStorage.php
+++ b/src/SimpleIdStorage.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId;
+namespace DR\SymfonyTraceBundle;
 
 /**
  * And ID storage backed by a property, simple.

--- a/src/SymfonyTraceBundle.php
+++ b/src/SymfonyTraceBundle.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 /**
  * @codeCoverageIgnore - This is a bundle class, tested by the functional test
  */
-final class TraceBundle extends Bundle
+final class SymfonyTraceBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {

--- a/src/TraceBundle.php
+++ b/src/TraceBundle.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId;
+namespace DR\SymfonyTraceBundle;
 
-use DR\SymfonyRequestId\DependencyInjection\Compiler\HttpClientTraceIdPass;
-use DR\SymfonyRequestId\DependencyInjection\SymfonyRequestIdExtension;
+use DR\SymfonyTraceBundle\DependencyInjection\Compiler\HttpClientTraceIdPass;
+use DR\SymfonyTraceBundle\DependencyInjection\SymfonyTraceExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 /**
  * @codeCoverageIgnore - This is a bundle class, tested by the functional test
  */
-final class RequestIdBundle extends Bundle
+final class TraceBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {
@@ -27,6 +27,6 @@ final class RequestIdBundle extends Bundle
      */
     public function getContainerExtension(): ExtensionInterface
     {
-        return new SymfonyRequestIdExtension();
+        return new SymfonyTraceExtension();
     }
 }

--- a/src/Twig/TraceIdExtension.php
+++ b/src/Twig/TraceIdExtension.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Twig;
+namespace DR\SymfonyTraceBundle\Twig;
 
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 

--- a/tests/Functional/App/EventSubscriber/StopWorkerEventSubscriber.php
+++ b/tests/Functional/App/EventSubscriber/StopWorkerEventSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Functional\App\EventSubscriber;
+namespace DR\SymfonyTraceBundle\Tests\Functional\App\EventSubscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;

--- a/tests/Functional/App/Messenger/TestMessage.php
+++ b/tests/Functional/App/Messenger/TestMessage.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Functional\App\Messenger;
+namespace DR\SymfonyTraceBundle\Tests\Functional\App\Messenger;
 
 class TestMessage
 {

--- a/tests/Functional/App/Monolog/MemoryHandler.php
+++ b/tests/Functional/App/Monolog/MemoryHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Functional\App\Monolog;
+namespace DR\SymfonyTraceBundle\Tests\Functional\App\Monolog;
 
 use Countable;
 use DR\Utils\Assert;

--- a/tests/Functional/App/Service/MockClientCallbackHelper.php
+++ b/tests/Functional/App/Service/MockClientCallbackHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Functional\App\Service;
+namespace DR\SymfonyTraceBundle\Tests\Functional\App\Service;
 
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\ResponseInterface;

--- a/tests/Functional/App/Service/TestIdStorage.php
+++ b/tests/Functional/App/Service/TestIdStorage.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Functional\App\Service;
+namespace DR\SymfonyTraceBundle\Tests\Functional\App\Service;
 
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 
 class TestIdStorage implements IdStorageInterface
 {

--- a/tests/Functional/App/TestKernel.php
+++ b/tests/Functional/App/TestKernel.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace DR\SymfonyTraceBundle\Tests\Functional\App;
 
-use DR\SymfonyTraceBundle\TraceBundle;
+use DR\SymfonyTraceBundle\SymfonyTraceBundle;
 use Exception;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\MonologBundle\MonologBundle;
@@ -23,7 +23,7 @@ final class TestKernel extends Kernel
             new FrameworkBundle(),
             new TwigBundle(),
             new MonologBundle(),
-            new TraceBundle(),
+            new SymfonyTraceBundle(),
         ];
     }
 

--- a/tests/Functional/App/TestKernel.php
+++ b/tests/Functional/App/TestKernel.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Functional\App;
+namespace DR\SymfonyTraceBundle\Tests\Functional\App;
 
-use DR\SymfonyRequestId\RequestIdBundle;
+use DR\SymfonyTraceBundle\TraceBundle;
 use Exception;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\MonologBundle\MonologBundle;
@@ -23,7 +23,7 @@ final class TestKernel extends Kernel
             new FrameworkBundle(),
             new TwigBundle(),
             new MonologBundle(),
-            new RequestIdBundle(),
+            new TraceBundle(),
         ];
     }
 

--- a/tests/Functional/App/config/config.yml
+++ b/tests/Functional/App/config/config.yml
@@ -13,14 +13,14 @@ framework:
     transports:
       test_transport: 'in-memory://'
     routing:
-      DR\SymfonyRequestId\Tests\Functional\App\Messenger\TestMessage: test_transport
+      DR\SymfonyTraceBundle\Tests\Functional\App\Messenger\TestMessage: test_transport
   http_method_override: false
   php_errors:
     log: true
   handle_all_throwables: true
   default_locale: "%locale%"
 
-symfony_request_id:
+symfony_trace:
   request_header: Trace-Id
   response_header: Trace-Id
   trust_request_header: true
@@ -42,21 +42,21 @@ services:
       - "[%%level_name%%][%%extra.trace_id%%][%%extra.transaction_id%%] %%message%%"
   log.memory_handler:
     public: true
-    class: DR\SymfonyRequestId\Tests\Functional\App\Monolog\MemoryHandler
+    class: DR\SymfonyTraceBundle\Tests\Functional\App\Monolog\MemoryHandler
     calls:
       - [ setFormatter, [ "@log.formatter" ] ]
   request.id.storage:
-    class: DR\SymfonyRequestId\Tests\Functional\App\Service\TestIdStorage
+    class: DR\SymfonyTraceBundle\Tests\Functional\App\Service\TestIdStorage
   stop.worker.event-subscriber:
-    class: DR\SymfonyRequestId\Tests\Functional\App\EventSubscriber\StopWorkerEventSubscriber
+    class: DR\SymfonyTraceBundle\Tests\Functional\App\EventSubscriber\StopWorkerEventSubscriber
     tags:
       - { name: kernel.event_subscriber }
-  DR\SymfonyRequestId\Tests\Functional\App\Service\MockClientCallbackHelper:
+  DR\SymfonyTraceBundle\Tests\Functional\App\Service\MockClientCallbackHelper:
   test.http_client:
     class: Symfony\Component\HttpClient\MockHttpClient
     public: true
     arguments:
-      - '@DR\SymfonyRequestId\Tests\Functional\App\Service\MockClientCallbackHelper'
+      - '@DR\SymfonyTraceBundle\Tests\Functional\App\Service\MockClientCallbackHelper'
     tags:
       - { name: 'http_client.trace_id' }
 monolog:

--- a/tests/Functional/ApplicationTest.php
+++ b/tests/Functional/ApplicationTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Functional;
+namespace DR\SymfonyTraceBundle\Tests\Functional;
 
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use Exception;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use Symfony\Bundle\FrameworkBundle\Console\Application;

--- a/tests/Functional/HttpClientTest.php
+++ b/tests/Functional/HttpClientTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Functional;
 
-use DR\SymfonyRequestId\Tests\Functional\App\Service\TestIdStorage;
+use DR\SymfonyTraceBundle\Tests\Functional\App\Service\TestIdStorage;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Contracts\HttpClient\HttpClientInterface;

--- a/tests/Functional/MessengerTest.php
+++ b/tests/Functional/MessengerTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Functional;
+namespace DR\SymfonyTraceBundle\Tests\Functional;
 
-use DR\SymfonyRequestId\Messenger\TraceIdStamp;
-use DR\SymfonyRequestId\IdStorageInterface;
-use DR\SymfonyRequestId\Tests\Functional\App\Messenger\TestMessage;
-use DR\SymfonyRequestId\Tests\Functional\App\Service\TestIdStorage;
+use DR\SymfonyTraceBundle\Messenger\TraceIdStamp;
+use DR\SymfonyTraceBundle\IdStorageInterface;
+use DR\SymfonyTraceBundle\Tests\Functional\App\Messenger\TestMessage;
+use DR\SymfonyTraceBundle\Tests\Functional\App\Service\TestIdStorage;
 use DR\Utils\Assert;
 use Exception;
 use PHPUnit\Framework\Attributes\CoversNothing;

--- a/tests/Functional/RequestHandleTest.php
+++ b/tests/Functional/RequestHandleTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Functional;
+namespace DR\SymfonyTraceBundle\Tests\Functional;
 
-use DR\SymfonyRequestId\IdGeneratorInterface;
-use DR\SymfonyRequestId\IdStorageInterface;
-use DR\SymfonyRequestId\Tests\Functional\App\Monolog\MemoryHandler;
+use DR\SymfonyTraceBundle\IdGeneratorInterface;
+use DR\SymfonyTraceBundle\IdStorageInterface;
+use DR\SymfonyTraceBundle\Tests\Functional\App\Monolog\MemoryHandler;
 use Exception;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\TestWith;

--- a/tests/Unit/EventSubscriber/CommandSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/CommandSubscriberTest.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Unit\EventSubscriber;
+namespace DR\SymfonyTraceBundle\Tests\Unit\EventSubscriber;
 
-use DR\SymfonyRequestId\EventSubscriber\CommandSubscriber;
-use DR\SymfonyRequestId\IdGeneratorInterface;
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\EventSubscriber\CommandSubscriber;
+use DR\SymfonyTraceBundle\IdGeneratorInterface;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/EventSubscriber/MessageBusSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/MessageBusSubscriberTest.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Unit\EventSubscriber;
+namespace DR\SymfonyTraceBundle\Tests\Unit\EventSubscriber;
 
-use DR\SymfonyRequestId\EventSubscriber\MessageBusSubscriber;
-use DR\SymfonyRequestId\IdGeneratorInterface;
-use DR\SymfonyRequestId\Messenger\TraceIdStamp;
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\EventSubscriber\MessageBusSubscriber;
+use DR\SymfonyTraceBundle\IdGeneratorInterface;
+use DR\SymfonyTraceBundle\Messenger\TraceIdStamp;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/EventSubscriber/TraceIdSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/TraceIdSubscriberTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Unit\EventSubscriber;
+namespace DR\SymfonyTraceBundle\Tests\Unit\EventSubscriber;
 
-use DR\SymfonyRequestId\EventSubscriber\TraceIdSubscriber;
-use DR\SymfonyRequestId\IdGeneratorInterface;
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\EventSubscriber\TraceIdSubscriber;
+use DR\SymfonyTraceBundle\IdGeneratorInterface;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Generator/RamseyUuid4GeneratorTest.php
+++ b/tests/Unit/Generator/RamseyUuid4GeneratorTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Unit\Generator;
+namespace DR\SymfonyTraceBundle\Tests\Unit\Generator;
 
-use DR\SymfonyRequestId\Generator\RamseyUuid4Generator;
+use DR\SymfonyTraceBundle\Generator\RamseyUuid4Generator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Generator/SymfonyUuid4GeneratorTest.php
+++ b/tests/Unit/Generator/SymfonyUuid4GeneratorTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Unit\Generator;
+namespace DR\SymfonyTraceBundle\Tests\Unit\Generator;
 
-use DR\SymfonyRequestId\Generator\SymfonyUuid4Generator;
+use DR\SymfonyTraceBundle\Generator\SymfonyUuid4Generator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Http/TraceIdAwareHttpClientTest.php
+++ b/tests/Unit/Http/TraceIdAwareHttpClientTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Unit\Http;
+namespace DR\SymfonyTraceBundle\Tests\Unit\Http;
 
-use DR\SymfonyRequestId\Http\TraceIdAwareHttpClient;
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\Http\TraceIdAwareHttpClient;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Monolog/TraceIdProcessorTest.php
+++ b/tests/Unit/Monolog/TraceIdProcessorTest.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Unit\Monolog;
+namespace DR\SymfonyTraceBundle\Tests\Unit\Monolog;
 
 use DateTimeImmutable;
-use DR\SymfonyRequestId\Monolog\TraceIdProcessor;
-use DR\SymfonyRequestId\IdStorageInterface;
+use DR\SymfonyTraceBundle\Monolog\TraceIdProcessor;
+use DR\SymfonyTraceBundle\IdStorageInterface;
 use Monolog\Level;
 use Monolog\Logger;
 use Monolog\LogRecord;

--- a/tests/Unit/SimpleIdStorageTest.php
+++ b/tests/Unit/SimpleIdStorageTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Unit;
+namespace DR\SymfonyTraceBundle\Tests\Unit;
 
-use DR\SymfonyRequestId\SimpleIdStorage;
+use DR\SymfonyTraceBundle\SimpleIdStorage;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Twig/TraceIdExtensionTest.php
+++ b/tests/Unit/Twig/TraceIdExtensionTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace DR\SymfonyRequestId\Tests\Unit\Twig;
+namespace DR\SymfonyTraceBundle\Tests\Unit\Twig;
 
-use DR\SymfonyRequestId\SimpleIdStorage;
-use DR\SymfonyRequestId\Twig\TraceIdExtension;
+use DR\SymfonyTraceBundle\SimpleIdStorage;
+use DR\SymfonyTraceBundle\Twig\TraceIdExtension;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Throwable;


### PR DESCRIPTION
To better fit the changes to the repo after the initial fork
- No longer request specific with addition of command/messenger tracing
- diverted from requestId to traceId + transactionId