### PR TITLE
Pass on http header 'traceparent' to current Symfony Request object

### DIFF
--- a/src/EventSubscriber/TraceSubscriber.php
+++ b/src/EventSubscriber/TraceSubscriber.php
@@ -64,10 +64,14 @@ final class TraceSubscriber implements EventSubscriberInterface
 
         // If the trace ID is already set by another process, don't overwrite it
         if ($this->traceStorage->getTraceId() !== null) {
+            #Add `traceparent` header for sentry to continue the trace
+            $request->headers->set('traceparent', $this->traceStorage->getTraceId());
             return;
         }
 
         $this->traceStorage->setTrace($this->traceService->createNewTrace());
+        #Add `traceparent` header for sentry to continue the trace
+        $request->headers->set('traceparent', $this->traceStorage->getTraceId());
     }
 
     public function onResponse(ResponseEvent $event): void

--- a/tests/Unit/EventSubscriber/TraceSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/TraceSubscriberTest.php
@@ -100,16 +100,20 @@ class TraceSubscriberTest extends TestCase
 
         $event = new RequestEvent($this->kernel, $this->request, HttpKernelInterface::MAIN_REQUEST);
         $this->dispatcher->dispatch($event, KernelEvents::REQUEST);
+
+        static::assertNull($this->request->headers->get('traceparent'));
     }
 
     public function testListenerDoesNothingWhenStorageIdIsFound(): void
     {
         $this->service->expects(static::once())->method('supports')->willReturn(false);
         $this->service->expects(static::never())->method('createNewTrace');
-        $this->storage->expects(static::once())->method('getTraceId')->willReturn("abc123");
+        $this->storage->expects(static::exactly(2))->method('getTraceId')->willReturn("abc123");
 
         $event = new RequestEvent($this->kernel, $this->request, HttpKernelInterface::MAIN_REQUEST);
         $this->dispatcher->dispatch($event, KernelEvents::REQUEST);
+
+        static::assertEquals('abc123', $this->request->headers->get('traceparent'));
     }
 
     public function testListenerDoesNothingToResponseWithoutMasterRequest(): void


### PR DESCRIPTION
Pass on http header 'traceparent' to Symfony Request object for Sentry to use and continue the trace